### PR TITLE
Adding new method to support JoyCons

### DIFF
--- a/src/sdlgyro.cpp
+++ b/src/sdlgyro.cpp
@@ -34,6 +34,29 @@ std::chrono::steady_clock::time_point newTime;
 
 GamepadMotion gyroSensor;
 
+// Joy-Con izquierdo y derecho
+// Estos son punteros a los controladores SDL para los Joy-Con izquierdo y derecho
+// Joy-Con izquierdo
+SDL_GameController *joy_con_left = nullptr;
+bool pollingEnabled_L = true;
+bool gyroEnabled_L = false;
+bool accelEnabled_L = false;
+Vector3 Gyro_L;
+Vector3 Accel_L;
+Vector4 Orientation_L;
+GamepadMotion gyroSensor_L;
+
+// Joy-Con derecho
+SDL_GameController *joy_con_right = nullptr;
+bool pollingEnabled_R = true;
+bool gyroEnabled_R = false;
+bool accelEnabled_R = false;
+Vector3 Gyro_R;
+Vector3 Accel_R;
+Vector4 Orientation_R;
+GamepadMotion gyroSensor_R;
+
+
 void SDLGyro::_bind_methods() {
   ClassDB::bind_method(D_METHOD("sdl_init"),&SDLGyro::sdl_init);
   ClassDB::bind_method(D_METHOD("controller_init"),&SDLGyro::controller_init);
@@ -48,9 +71,19 @@ void SDLGyro::_bind_methods() {
   ClassDB::bind_method(D_METHOD("set_auto_calibration"),&SDLGyro::setAutoCalibration);
   ClassDB::bind_method(D_METHOD("is_gyro_steady"),&SDLGyro::isCalibrationSteady);
   ClassDB::bind_method(D_METHOD("get_calibration_confidence"),&SDLGyro::getCalibrationConfidence);
+  ClassDB::bind_method(D_METHOD("get_available_gyro_controllers"), &SDLGyro::get_available_gyro_controllers);
+  ClassDB::bind_method(D_METHOD("get_gamepad_name", "controller_index"), &SDLGyro::get_gamepad_name);
+  ClassDB::bind_method(D_METHOD("poll_motion_data", "controller_index"), &SDLGyro::poll_motion_data);
+  ClassDB::bind_method(D_METHOD("poll_both_joycon_gyros", "controller_index"), &SDLGyro::poll_both_joycon_gyros);
+  ClassDB::bind_method(D_METHOD("init_joycons"), &SDLGyro::init_joycons);
+  ClassDB::bind_method(D_METHOD("joycon_polling"), &SDLGyro::joycon_polling);
+  ClassDB::bind_method(D_METHOD("joycon_calibrate"), &SDLGyro::joycon_calibrate);
+  ClassDB::bind_method(D_METHOD("joycon_stop_calibrate"), &SDLGyro::joycon_stop_calibrate);
+  ClassDB::bind_method(D_METHOD("joycon_auto_calibration"), &SDLGyro::joycon_auto_calibration);
 }
 
 void SDLGyro::sdl_init() {
+  
   newTime=std::chrono::steady_clock::now();
   oldTime=newTime;
   //SDL initializATION
@@ -205,4 +238,240 @@ Variant SDLGyro::gamepadPolling(){
     orientation = Vector4(1.0,0.0,0.0,0.0);
     return orientation;
   }
+}
+
+// Polls motion data from a specific controller index
+Array SDLGyro::get_available_gyro_controllers() {
+  Array result;
+  for (int i = 0; i < SDL_NumJoysticks(); i++) {
+    if (SDL_IsGameController(i)) {
+      SDL_GameController *temp = SDL_GameControllerOpen(i);
+      if (!temp) continue;
+
+      if (SDL_GameControllerHasSensor(temp, SDL_SENSOR_GYRO)) {
+        result.append(i);
+      }
+      SDL_GameControllerClose(temp);
+    }
+  }
+  return result;
+}
+
+// Polls motion data from a specific controller index
+String SDLGyro::get_gamepad_name(int controller_index) {
+  if (SDL_IsGameController(controller_index)) {
+    const char* name = SDL_GameControllerNameForIndex(controller_index);
+    if (name) return String(name);
+  }
+  return "[Desconocido]";
+}
+
+
+// Polls motion data from a specific controller index
+Variant SDLGyro::poll_motion_data(int controller_index) {
+  if (!SDL_IsGameController(controller_index)) {
+    UtilityFunctions::print("Controlador inválido\n");
+    return Variant();
+  }
+
+  SDL_GameController* temp = SDL_GameControllerOpen(controller_index);
+  if (!temp) return Variant();
+
+  if (!SDL_GameControllerHasSensor(temp, SDL_SENSOR_GYRO)) {
+    SDL_GameControllerClose(temp);
+    UtilityFunctions::print("Este mando no tiene giroscopio\n");
+    return Variant();
+  }
+
+  float gyro[3];
+  SDL_GameControllerSetSensorEnabled(temp, SDL_SENSOR_GYRO, SDL_TRUE);
+  SDL_GameControllerGetSensorData(temp, SDL_SENSOR_GYRO, gyro, 3);
+  SDL_GameControllerClose(temp);
+
+  Vector3 v(gyro[0] * toDegPerSec, gyro[1] * toDegPerSec, gyro[2] * toDegPerSec);
+  return v;
+}
+
+// Polls both Joy-Con gyros and returns their data in a Dictionary
+Dictionary SDLGyro::poll_both_joycon_gyros(int controller_index) {
+    Dictionary result;
+
+    if (!SDL_IsGameController(controller_index)) {
+        UtilityFunctions::print("Controlador inválido\n");
+        return result;
+    }
+
+    SDL_GameController *gc = SDL_GameControllerOpen(controller_index);
+    if (!gc) {
+        UtilityFunctions::print("No se pudo abrir el controlador\n");
+        return result;
+    }
+
+    float gyro_l[3] = {0}, gyro_r[3] = {0};
+
+    // Gyro Izquierdo
+    if (SDL_GameControllerHasSensor(gc, SDL_SENSOR_GYRO_L)) {
+        SDL_GameControllerSetSensorEnabled(gc, SDL_SENSOR_GYRO_L, SDL_TRUE);
+        SDL_GameControllerGetSensorData(gc, SDL_SENSOR_GYRO_L, gyro_l, 3);
+    }
+
+    // Gyro Derecho
+    if (SDL_GameControllerHasSensor(gc, SDL_SENSOR_GYRO_R)) {
+        SDL_GameControllerSetSensorEnabled(gc, SDL_SENSOR_GYRO_R, SDL_TRUE);
+        SDL_GameControllerGetSensorData(gc, SDL_SENSOR_GYRO_R, gyro_r, 3);
+    }
+
+    SDL_GameControllerClose(gc);
+
+    result["gyro_left"] = Vector3(gyro_l[0] * toDegPerSec, gyro_l[1] * toDegPerSec, gyro_l[2] * toDegPerSec);
+    result["gyro_right"] = Vector3(gyro_r[0] * toDegPerSec, gyro_r[1] * toDegPerSec, gyro_r[2] * toDegPerSec);
+
+    return result;
+}
+
+// Initializes Joy-Con controllers if both left and right sensors are available
+void SDLGyro::init_joycons() {
+    int total = SDL_NumJoysticks();
+
+    for (int i = 0; i < total; i++) {
+        if (!SDL_IsGameController(i)) continue;
+
+        SDL_GameController *gc = SDL_GameControllerOpen(i);
+        if (!gc) continue;
+
+        // Revisamos si este mando tiene ambos sensores L y R
+        if (SDL_GameControllerHasSensor(gc, SDL_SENSOR_GYRO_L) &&
+            SDL_GameControllerHasSensor(gc, SDL_SENSOR_GYRO_R)) {
+            
+            SDL_GameControllerSetSensorEnabled(gc, SDL_SENSOR_GYRO_L, SDL_TRUE);
+            SDL_GameControllerSetSensorEnabled(gc, SDL_SENSOR_ACCEL_L, SDL_TRUE);
+            SDL_GameControllerSetSensorEnabled(gc, SDL_SENSOR_GYRO_R, SDL_TRUE);
+            SDL_GameControllerSetSensorEnabled(gc, SDL_SENSOR_ACCEL_R, SDL_TRUE);
+
+            controller = gc;
+
+            gyroEnabled_L = accelEnabled_L = true;
+            gyroEnabled_R = accelEnabled_R = true;
+
+            UtilityFunctions::print("Joy-Con izquierdo y derecho inicializados.");
+            break;
+        } else {
+            SDL_GameControllerClose(gc);
+        }
+    }
+
+    if (!controller) {
+        UtilityFunctions::print("No están conectados ambos sensores (L/R).");
+    }
+}
+
+
+
+// Polls motion data from Joy-Con controllers
+// TODO: 
+Dictionary SDLGyro::joycon_polling() {
+    Dictionary result;
+
+    auto now = std::chrono::steady_clock::now();
+    deltaTime = ((float)std::chrono::duration_cast<std::chrono::microseconds>(now - oldTime).count()) / 1000000.0f;
+    oldTime = now;
+
+    // Joy-Con izquierdo
+    if (gyroEnabled_L && accelEnabled_L && pollingEnabled_L && controller) {
+        SDL_GameControllerGetSensorData(controller, SDL_SENSOR_GYRO_L, &Gyro_L[0], 3);
+        SDL_GameControllerGetSensorData(controller, SDL_SENSOR_ACCEL_L, &Accel_L[0], 3);
+
+        gyroSensor_L.ProcessMotion(
+            Gyro_L[0] * toDegPerSec, Gyro_L[1] * toDegPerSec, Gyro_L[2] * toDegPerSec,
+            Accel_L[0] * toGs, Accel_L[1] * toGs, Accel_L[2] * toGs,
+            deltaTime
+        );
+
+        // Joy-Con derecho
+        if (gyroEnabled_R && accelEnabled_R && pollingEnabled_R && controller) {
+            SDL_GameControllerGetSensorData(controller, SDL_SENSOR_GYRO_R, &Gyro_R[0], 3);
+            SDL_GameControllerGetSensorData(controller, SDL_SENSOR_ACCEL_R, &Accel_R[0], 3);
+    
+            gyroSensor_R.ProcessMotion(
+                Gyro_R[0] * toDegPerSec, Gyro_R[1] * toDegPerSec, Gyro_R[2] * toDegPerSec,
+                Accel_R[0] * toGs, Accel_R[1] * toGs, Accel_R[2] * toGs,
+                deltaTime
+            );
+    
+            gyroSensor_R.GetOrientation(
+                Orientation_R[0], Orientation_R[1], Orientation_R[2], Orientation_R[3]
+            );
+        }
+        gyroSensor_L.GetOrientation(
+            Orientation_L[0], Orientation_L[1], Orientation_L[2], Orientation_L[3]
+        );
+    }
+
+
+    // IMPORTANTE: procesar el event loop para mantener SDL funcionando correctamente
+    while (SDL_PollEvent(&event)) {
+        switch (event.type) {
+            case SDL_CONTROLLERDEVICEADDED:
+                // Podrías volver a llamar a init_joycons() si necesitas reconectar
+                break;
+
+            case SDL_CONTROLLERDEVICEREMOVED:
+                SDL_GameControllerClose(controller);
+                controller = nullptr;
+                gyroEnabled_L = accelEnabled_L = false;
+                gyroEnabled_R = accelEnabled_R = false;
+                break;
+
+            case SDL_QUIT:
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if( pollingEnabled_L && pollingEnabled_R){
+      // Guardamos en el diccionario
+      result["left"] = Orientation_L;
+      result["right"] = Orientation_R;
+      return result;
+    }
+
+    else{
+      result["left"] = Vector4(1.0, 0.0, 0.0, 0.0);
+      result["right"] = Vector4(1.0, 0.0, 0.0, 0.0);
+      return result;
+    }
+}
+
+
+// Starts the continuous calibration for both Joy-Con gyros
+void SDLGyro::joycon_calibrate() {
+    gyroSensor_L.Reset();
+    gyroSensor_R.Reset();
+
+    pollingEnabled_L = false;
+    pollingEnabled_R = false;
+    
+    gyroSensor_L.StartContinuousCalibration();
+    gyroSensor_R.StartContinuousCalibration();
+}
+
+
+// Stops the continuous calibration for both Joy-Con gyros
+void SDLGyro::joycon_stop_calibrate() {
+    gyroSensor_L.PauseContinuousCalibration();
+    gyroSensor_R.PauseContinuousCalibration();
+
+    pollingEnabled_L = true;
+    pollingEnabled_R = true;
+}
+
+
+// Auto calibration for the Joy-Con gyros
+// This function sets the calibration mode to use stillness and sensor fusion
+void SDLGyro::joycon_auto_calibration(){
+  gyroSensor_L.SetCalibrationMode(GamepadMotionHelpers::Stillness | GamepadMotionHelpers::SensorFusion);
+  gyroSensor_R.SetCalibrationMode(GamepadMotionHelpers::Stillness | GamepadMotionHelpers::SensorFusion);
+
 }

--- a/src/sdlgyro.h
+++ b/src/sdlgyro.h
@@ -13,6 +13,20 @@ using namespace godot;
 
       Variant gamepadPolling();
 
+      // Modificacion Multiples controles
+      Array get_available_gyro_controllers();
+      String get_gamepad_name(int controller_index);
+      Variant poll_motion_data(int controller_index);
+      godot::Dictionary poll_both_joycon_gyros(int controller_index);
+
+      // Funciones para Joy-Con
+      void init_joycons();
+      Dictionary joycon_polling();
+      void joycon_calibrate();
+      void joycon_stop_calibrate();
+      void joycon_auto_calibration();
+
+
       void calibrate();
       void stop_calibrate();
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `SDLGyro` class, focusing on support for Joy-Con controllers and gyro-related functionality. The changes include new methods for handling Joy-Con initialization, polling, calibration, and motion data retrieval, as well as updates to the class bindings and header file to support these features.

### Joy-Con Support and Motion Data Handling:

* **Joy-Con Initialization and Polling**: Added methods to initialize Joy-Con controllers (`init_joycons`) and continuously poll motion data (`joycon_polling`). These methods enable seamless integration of both left and right Joy-Con sensors for gyro and accelerometer data. 
* **Motion Data Retrieval**: Introduced methods to retrieve motion data from specific controllers (`poll_motion_data`) and both Joy-Con gyros (`poll_both_joycon_gyros`). These methods allow precise access to gyro data for individual controllers and combined Joy-Con sensors. 

### Calibration Enhancements:

* **Joy-Con Calibration**: Added methods for continuous calibration (`joycon_calibrate`), stopping calibration (`joycon_stop_calibrate`), and automatic calibration using stillness and sensor fusion (`joycon_auto_calibration`). These features improve the accuracy of gyro data by ensuring proper calibration.

### Class Bindings and Header Updates:

* **Class Bindings**: Updated `_bind_methods` to include bindings for new Joy-Con and gyro-related methods, ensuring they are accessible in the Godot engine.
* **Header File Updates**: Modified `sdlgyro.h` to declare new methods for Joy-Con handling and motion data retrieval, aligning the header file with the implementation changes. 